### PR TITLE
Check widget orderby value against the correct set of options in update

### DIFF
--- a/inc/widgets/class-list-posts.php
+++ b/inc/widgets/class-list-posts.php
@@ -109,7 +109,7 @@ class List_Posts extends \WP_Widget {
 		$orderby = array( 'ID', 'author', 'none', 'title', 'name', 'date', 'modified', 'random', 'comment_count' );
 
 		$instance['order']   = in_array( $new_instance['order'], $order )   ? $new_instance['order']  : 'ASC';
-		$instance['orderby'] = in_array( $new_instance['orderby'], $order )   ? $new_instance['orderby']  : 'date';
+		$instance['orderby'] = in_array( $new_instance['orderby'], $orderby )   ? $new_instance['orderby']  : 'date';
 
 		// Integers.
 		$instance['posts_per_page'] = intval( $new_instance['posts_per_page'] );

--- a/inc/widgets/class-list-related.php
+++ b/inc/widgets/class-list-related.php
@@ -114,7 +114,7 @@ class List_Related extends \WP_Widget {
 		$orderby = array( 'ID', 'author', 'none', 'title', 'name', 'date', 'modified', 'random', 'comment_count' );
 
 		$instance['order']   = in_array( $new_instance['order'], $order )   ? $new_instance['order']  : 'ASC';
-		$instance['orderby'] = in_array( $new_instance['orderby'], $order )   ? $new_instance['orderby']  : 'date';
+		$instance['orderby'] = in_array( $new_instance['orderby'], $orderby )   ? $new_instance['orderby']  : 'date';
 
 		// Integers.
 		$instance['posts_per_page'] = intval( $new_instance['posts_per_page'] );


### PR DESCRIPTION
The update method for both widgets was checking the chosen option for 'orderby' against the permitted options for 'order'.