### PR TITLE
Update __toString docblock to declare a return type of string

### DIFF
--- a/series.php
+++ b/series.php
@@ -90,7 +90,7 @@ final class Plugin {
 	 *
 	 * @since  2.0.0
 	 * @access public
-	 * @return void
+	 * @return string
 	 */
 	public function __toString() {
 		return 'series';


### PR DESCRIPTION
The `__toString()` magic method's docblock listed its return type as void rather than string.